### PR TITLE
lorax: Remove branding code

### DIFF
--- a/lorax/0004-Remove-branding-code.patch
+++ b/lorax/0004-Remove-branding-code.patch
@@ -1,0 +1,60 @@
+From 56a5816b152477b5fd057ed53c55863d59900f41 Mon Sep 17 00:00:00 2001
+From: Wojtek Porczyk <woju@invisiblethingslab.com>
+Date: Thu, 16 Jun 2016 18:53:18 +0200
+Subject: [PATCH] Remove branding code
+
+This code caused transient build failures when there is more than one
+package that provides /etc/system-release _available_ in any of the
+repositories, irrespective of _any_ dependecies whatsoever. The failure
+is non-deterministic, because depends on the order of packages returned
+by search query.
+
+Automatic branding install is stupid anyway and should instead be done
+by package groups, kickstarts and/or whatever. But it does not surprise
+me at all, because this is package is maintained as part of Fedora/RH.
+
+Signed-off-by: Wojtek Porczyk <woju@invisiblethingslab.com>
+---
+ src/pylorax/treebuilder.py | 24 ------------------------
+ 1 file changed, 24 deletions(-)
+
+diff --git a/src/pylorax/treebuilder.py b/src/pylorax/treebuilder.py
+index 5d4f8b7..1bf9f22 100644
+--- a/src/pylorax/treebuilder.py
++++ b/src/pylorax/treebuilder.py
+@@ -88,32 +88,8 @@ class RuntimeBuilder(object):
+         self._runner.defaults = self.vars
+         self.dbo.reset()
+ 
+-    def _install_branding(self):
+-        release = None
+-        q = self.dbo.sack.query()
+-        a = q.available()
+-        for pkg in a.filter(provides='/etc/system-release'):
+-            if pkg.name.startswith('generic'):
+-                continue
+-            else:
+-                release = pkg.name
+-                break
+-
+-        if not release:
+-            logger.error('could not get the release')
+-            return
+-
+-        # release
+-        logger.info('got release: %s', release)
+-        self._runner.installpkg(release)
+-
+-        # logos
+-        release, _suffix = release.split('-', 1)
+-        self._runner.installpkg('%s-logos' % release)
+-
+     def install(self):
+         '''Install packages and do initial setup with runtime-install.tmpl'''
+-        self._install_branding()
+         if len(self._installpkgs) > 0:
+             self._runner.installpkg(*self._installpkgs)
+         self._runner.run("runtime-install.tmpl")
+-- 
+2.5.5
+

--- a/lorax/lorax.spec
+++ b/lorax/lorax.spec
@@ -22,6 +22,7 @@ Patch0:         Drop-multiprocessing-for-do_transaction-1208296.patch
 Patch1:         0001-Allow-specify-gpg-key-for-a-repository.patch
 Patch2:         0002-verify-packages-signature.patch
 Patch3:         0003-Update-package-verification-for-dnf-API.patch
+Patch4:         0004-Remove-branding-code.patch
 
 BuildRequires:  python3-devel
 BuildRequires:  python3-pocketlint >= 0.5
@@ -117,6 +118,7 @@ to run Anaconda.
 %patch1 -p1
 %patch2 -p1
 %patch3 -p1
+%patch4 -p1
 
 %build
 


### PR DESCRIPTION
This code caused transient build failures when there is more than one
package that provides /etc/system-release _available_ in any of the
repositories, irrespective of _any_ dependecies whatsoever. The failure
is non-deterministic, because depends on the order of packages returned
by search query.

Automatic branding install is stupid anyway and should instead be done
by package groups, kickstarts and/or whatever. But it does not surprise
me at all, because this is package is maintained as part of Fedora/RH.

fixes QubesOS/qubes-issues#2076
