### PR TITLE
live: fix kickstart file path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ iso-installer: iso-prepare
 
 iso-liveusb: $(LIVE_KICKSTART) iso-prepare
 	mkdir -p work
-	pushd work && ../livecd-creator-qubes --debug --product='Qubes OS' --title="Qubes OS $(ISO_VERSION)" --fslabel="Qubes-$(ISO_VERSION)-x86_64-LIVE" --config ../$< && popd
+	pushd work && ../livecd-creator-qubes --debug --product='Qubes OS' --title="Qubes OS $(ISO_VERSION)" --fslabel="Qubes-$(ISO_VERSION)-x86_64-LIVE" --config $(LIVE_KICKSTART) && popd
 	# Move result files to known-named directories
 	mkdir -p build/ISO/qubes-x86_64/iso build/work
 	mv work/*.iso build/ISO/qubes-x86_64/iso/


### PR DESCRIPTION
Somebody reported on irc that building the live iso failed for them. The build
log clearly showed that the wrong path gets passed to the livecd creator script
(broken by 68ab062c).

I did not verify if that's the only problem with the live iso. Maybe this
should be added to the travis test.
