### PR TITLE
Add xdotool to default install

### DIFF
--- a/conf/comps-qubes.xml
+++ b/conf/comps-qubes.xml
@@ -1011,6 +1011,7 @@
       <packagereq type="mandatory">glx-utils</packagereq>
       <packagereq type="mandatory">gnome-packagekit</packagereq>
       <packagereq type="mandatory">mesa-dri-drivers</packagereq>
+      <packagereq type="mandatory">xdotool</packagereq>
       <packagereq type="mandatory">xorg-x11-drivers</packagereq>
       <packagereq type="mandatory">xorg-x11-drv-libinput</packagereq>
       <packagereq type="mandatory">xorg-x11-server-Xorg</packagereq>


### PR DESCRIPTION
Needed for better window killing: https://github.com/QubesOS/qubes-issues/issues/881#issuecomment-259903338

Addition approved by @marmarek in https://github.com/QubesOS/qubes-issues/issues/881#issuecomment-259927960