### PR TITLE
Add missing cvs dependency

### DIFF
--- a/pungi/pungi.spec
+++ b/pungi/pungi.spec
@@ -23,6 +23,7 @@ BuildRequires:  python-devel, python-setuptools, python2-productmd
 BuildRequires:  python-lockfile, kobo, kobo-rpmlib, python-kickstart, createrepo_c
 BuildRequires:  python-lxml, libselinux-python, yum-utils, lorax
 BuildRequires:  yum => 3.4.3-28, createrepo >= 0.4.11
+BuildRequires:  cvs
 #deps for doc building
 BuildRequires:  python-sphinx
 


### PR DESCRIPTION
```
-> Building installer-qubes-os (pungi/pungi.spec) for fc23 dom0 (logfile: build-logs/installer-qubes-os-dom0-fc23.log)
--> build failed!
[...]
+ cd tests
+ ./test_compose.sh
Program '/usr/bin/cvs' doesn't exist. Install package 'cvs'.
error: Bad exit status from /var/tmp/rpm-tmp.2W62Ai (%check)
```