### PR TITLE
qubes-anaconda-addon: fix setting default DispVM

### DIFF
--- a/qubes-anaconda-addon/org_qubes_os_initial_setup/gui/spokes/qubes_os.py
+++ b/qubes-anaconda-addon/org_qubes_os_initial_setup/gui/spokes/qubes_os.py
@@ -540,7 +540,9 @@ class QubesOsSpoke(FirstbootOnlySpokeMixIn, NormalSpoke):
         dispvm_name = self.default_template + '-dvm'
         self.run_command(['/usr/bin/qvm-create', '--label', 'red', dispvm_name])
         self.run_command(['/usr/bin/qvm-prefs', dispvm_name, 'dispvm_allowed', 'True'])
-        self.run_command(['/usr/bin/qubes-prefs', 'default-dispvm', default_dispvm])
+        self.run_command(['/usr/bin/qvm-features', dispvm_name, 'internal', 'True'])
+        self.run_command(['/usr/bin/qubes-prefs', 'default-dispvm',
+            dispvm_name])
 
     def configure_network(self):
         self.set_stage('Setting up networking')


### PR DESCRIPTION
Also hide it from application menu.

Fixes QubesOS/qubes-issues#2911