### PR TITLE
Don't ignore ignoregroups option for repos configured in kickstart file

### DIFF
--- a/scripts/ksparser
+++ b/scripts/ksparser
@@ -22,6 +22,9 @@ gpgcheck=1
 gpgkey={{ks_repo.gpgkey}}
 {% else %}
 gpgcheck=0
+{%- endif -%}
+{%- if ks_repo.ignoregroups %}
+enablegroups=0
 {% endif -%}
 """
 


### PR DESCRIPTION
Ignoring it leads to loading default Fedora groups for dom0, instead of
Qubes ones that are trimmed down.