### PR TITLE
(release4.0) use %autosetup, picking up the XFS reflink patch

### DIFF
--- a/blivet/python-blivet.spec
+++ b/blivet/python-blivet.spec
@@ -83,6 +83,7 @@ configuration.
 
 %patch100 -p1
 %patch101 -p1
+%patch102 -p1
 
 rm -rf %{py3dir}
 cp -a . %{py3dir}

--- a/blivet/python-blivet.spec
+++ b/blivet/python-blivet.spec
@@ -73,17 +73,7 @@ The python3-%{realname} is a python3 package for examining and modifying storage
 configuration.
 
 %prep
-%setup -q -n %{realname}-%{realversion}
-%patch0 -p1
-%patch1 -p1
-%patch2 -p1
-%patch3 -p1
-%patch4 -p1
-%patch5 -p1
-
-%patch100 -p1
-%patch101 -p1
-%patch102 -p1
+%autosetup -p1 -n %{realname}-%{realversion}
 
 rm -rf %{py3dir}
 cp -a . %{py3dir}

--- a/live/qubes-live.spec
+++ b/live/qubes-live.spec
@@ -19,6 +19,7 @@ Requires(post): kernel
 Various fixes for Qubes Live edition
 
 %prep
+%autosetup -p1
 
 %build
 

--- a/livecd-tools/livecd-tools.spec
+++ b/livecd-tools/livecd-tools.spec
@@ -79,11 +79,7 @@ like live image or appliances.
 
 
 %prep
-%setup -q
-
-%patch0 -p1
-%patch1 -p1
-%patch2 -p1
+%autosetup -p1
 
 %build
 make

--- a/lorax-templates-qubes/lorax-templates-qubes.spec
+++ b/lorax-templates-qubes/lorax-templates-qubes.spec
@@ -16,7 +16,7 @@ BuildArch:      noarch
 Lorax templates for Qubes installation ISO.
 
 %prep
-%setup -q
+%autosetup -p1
 
 %install
 rm -rf $RPM_BUILD_ROOT

--- a/lorax/lorax.spec
+++ b/lorax/lorax.spec
@@ -120,12 +120,7 @@ Lorax templates for creating the boot.iso and live isos are placed in
 /usr/share/lorax/templates.d/99-generic
 
 %prep
-%setup -q -n %{name}-%{version}
-
-%patch1 -p1
-%patch2 -p1
-%patch3 -p1
-%patch4 -p1
+%autosetup -p1 -n %{name}-%{version}
 
 %build
 

--- a/pungi/pungi.spec
+++ b/pungi/pungi.spec
@@ -78,14 +78,7 @@ notification to Fedora Message Bus.
 
 
 %prep
-%setup -q
-
-%patch1 -p1
-%patch2 -p1
-%patch3 -p1
-%patch4 -p1
-#%%patch5 -p1
-#%%patch6 -p1
+%autosetup -p1
 
 %build
 %{__python} setup.py build

--- a/pykickstart/pykickstart.spec
+++ b/pykickstart/pykickstart.spec
@@ -74,13 +74,7 @@ Python 3 library for manipulating kickstart files.  The binaries are found in
 the pykickstart package.
 
 %prep
-%setup -q
-
-%patch0 -p1
-%patch1 -p1
-%patch2 -p1
-%patch3 -p1
-%patch4 -p1
+%autosetup -p1
 
 rm -rf %{py3dir}
 mkdir %{py3dir}

--- a/qubes-anaconda-addon/qubes-anaconda-addon.spec
+++ b/qubes-anaconda-addon/qubes-anaconda-addon.spec
@@ -20,7 +20,7 @@ This is an addon that makes available Qubes OS specific setup functionality
 at first boot time.
 
 %prep
-%setup -q
+%autosetup -p1
 
 %install
 rm -rf $RPM_BUILD_ROOT

--- a/qubes-release/qubes-dom0-dist-upgrade.spec
+++ b/qubes-release/qubes-dom0-dist-upgrade.spec
@@ -14,7 +14,7 @@ BuildArch:	noarch
 Qubes dom0 upgrade transitional package.
 
 %prep
-%setup -q
+%autosetup -p1
 
 %install
 rm -rf $RPM_BUILD_ROOT

--- a/qubes-release/qubes-release.spec
+++ b/qubes-release/qubes-release.spec
@@ -36,7 +36,7 @@ Qubes release notes package.
 
 
 %prep
-%setup -q
+%autosetup -p1
 
 %install
 rm -rf $RPM_BUILD_ROOT


### PR DESCRIPTION
The XFS reflink patch wasn't picked up for the 4.0.4-rc2 iso.