### PR TITLE
Switch from wget to curl

### DIFF
--- a/livecd-tools/Makefile
+++ b/livecd-tools/Makefile
@@ -9,9 +9,13 @@ endif
 
 get-sources: $(SRC_FILE)
 
+ifeq ($(FETCH_CMD),)
+$(error "You can not run this Makefile without having FETCH_CMD defined")
+endif
+
 $(SRC_FILE):
 ifneq ($(SRC_FILE), None)
-	@wget -q $(URL)
+	@$(FETCH_CMD) $(SRC_FILE) $(URL)
 endif
 
 .PHONY: verify-sources


### PR DESCRIPTION
curl has a better security track record than wget, and on Fedora uses a
better TLS library (OpenSSL instead of GnuTLS).  This change also adds
REPO_PROXY support.