### PR TITLE
Always include kernel-latest on the installation ISO

### DIFF
--- a/conf/qubes-kickstart.cfg
+++ b/conf/qubes-kickstart.cfg
@@ -26,6 +26,8 @@ repo --name=dom0-updates --baseurl=file:///tmp/qubes-installer/yum/dom0-updates/
 @fedora
 @debian
 @whonix
+kernel-latest
+kernel-latest-qubes-vm
 # weaks dependencies
 -adobe-source-code-pro-fonts
 -compat-f32-dejavu-sans-fonts


### PR DESCRIPTION
It will be installed, if the user chooses to boot kernel-latest for the
installation itself.

QubesOS/qubes-issues#5900